### PR TITLE
Update github.com/creachadair/jrpc2 to v0.19.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module pkg.nimblebun.works/tsc-language-server
 go 1.15
 
 require (
-	github.com/creachadair/jrpc2 v0.10.3
+	github.com/creachadair/jrpc2 v0.19.0
 	github.com/spf13/afero v1.4.1
 	github.com/urfave/cli/v2 v2.2.0
 	pkg.nimblebun.works/go-lsp v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
-bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
-bitbucket.org/creachadair/stringset v0.0.9 h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=
-bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/creachadair/jrpc2 v0.10.3 h1:lSNkDMdPe/fnqvFnqzx7HDwoqOvcbgKKuwlZWHkoPmA=
-github.com/creachadair/jrpc2 v0.10.3/go.mod h1:nqChISpSPLx6JvoPKl+ihTJqqOqp9fgT2jnNrC6oXs4=
-github.com/creachadair/staticfile v0.1.3/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
+github.com/creachadair/jrpc2 v0.19.0 h1:Z+4Q/lmuzqD/NWqOcNqEXEApWy5TApeRRiPDtSWm0g4=
+github.com/creachadair/jrpc2 v0.19.0/go.mod h1:gaeysmTjY/kHSaCEjxF1pHXl8bc0X5otQPnQiA6r9Xk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -28,8 +24,8 @@ github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/langserver/diagnostics/diagnostics.go
+++ b/langserver/diagnostics/diagnostics.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/creachadair/jrpc2"
-	"pkg.nimblebun.works/go-lsp"
+	lsp "pkg.nimblebun.works/go-lsp"
 )
 
 // DocumentContext contains data about the document on which we have performed
@@ -27,7 +27,8 @@ type Notifier struct {
 
 func publishDiagnostics(docs <-chan DocumentContext, logger *log.Logger) {
 	for doc := range docs {
-		if err := jrpc2.PushNotify(doc.Ctx, "textDocument/publishDiagnostics", lsp.PublishDiagnosticsParams{
+		srv := jrpc2.ServerFromContext(doc.Ctx)
+		if err := srv.Notify(doc.Ctx, "textDocument/publishDiagnostics", lsp.PublishDiagnosticsParams{
 			URI:         doc.URI,
 			Diagnostics: doc.Diagnostics,
 		}); err != nil {

--- a/langserver/handlers/cancel_request.go
+++ b/langserver/handlers/cancel_request.go
@@ -4,19 +4,16 @@ import (
 	"context"
 
 	"github.com/creachadair/jrpc2"
-	"pkg.nimblebun.works/go-lsp"
+	lsp "pkg.nimblebun.works/go-lsp"
 )
 
 // CancelRequest will be called on "$/cancelRequest"
 func CancelRequest(ctx context.Context, req *jrpc2.Request) error {
 	var params lsp.CancelParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
-
-	if err != nil {
+	if err := req.UnmarshalParams(&params); err != nil {
 		return err
 	}
 
-	id := params.ID.String()
-	jrpc2.CancelRequest(ctx, id)
+	jrpc2.ServerFromContext(ctx).CancelRequest(params.ID.String())
 	return nil
 }

--- a/langserver/handlers/did_change.go
+++ b/langserver/handlers/did_change.go
@@ -14,7 +14,7 @@ import (
 // "textDocument/didChange" method
 func (mh *MethodHandler) TextDocumentDidChange(ctx context.Context, req *jrpc2.Request) error {
 	var params lsp.DidChangeTextDocumentParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
+	err := req.UnmarshalParams(&params)
 	if err != nil {
 		return err
 	}

--- a/langserver/handlers/did_close.go
+++ b/langserver/handlers/did_close.go
@@ -13,7 +13,7 @@ import (
 // method
 func (mh *MethodHandler) TextDocumentDidClose(ctx context.Context, req *jrpc2.Request) error {
 	var params lsp.DidCloseTextDocumentParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
+	err := req.UnmarshalParams(&params)
 	if err != nil {
 		return err
 	}

--- a/langserver/handlers/did_open.go
+++ b/langserver/handlers/did_open.go
@@ -14,7 +14,7 @@ import (
 // method
 func (mh *MethodHandler) TextDocumentDidOpen(ctx context.Context, req *jrpc2.Request) error {
 	var params lsp.DidOpenTextDocumentParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
+	err := req.UnmarshalParams(&params)
 	if err != nil {
 		return err
 	}

--- a/langserver/handlers/document_symbol.go
+++ b/langserver/handlers/document_symbol.go
@@ -16,7 +16,7 @@ func (mh *MethodHandler) TextDocumentSymbol(ctx context.Context, req *jrpc2.Requ
 	var symbols []lsp.DocumentSymbol
 
 	var params lsp.DocumentSymbolParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
+	err := req.UnmarshalParams(&params)
 	if err != nil {
 		return symbols, err
 	}

--- a/langserver/handlers/folding.go
+++ b/langserver/handlers/folding.go
@@ -14,7 +14,7 @@ import (
 // "textDocument/foldingRange" method.
 func (mh *MethodHandler) TextDocumentFoldingRange(ctx context.Context, req *jrpc2.Request) ([]lsp.FoldingRange, error) {
 	var params lsp.FoldingRangeParams
-	err := req.UnmarshalParams(jrpc2.NonStrict(&params))
+	err := req.UnmarshalParams(&params)
 	if err != nil {
 		return []lsp.FoldingRange{}, err
 	}

--- a/langserver/handlers/service.go
+++ b/langserver/handlers/service.go
@@ -236,7 +236,7 @@ func (service *Service) Assigner() (jrpc2.Assigner, error) {
 }
 
 // Finish will terminate the service
-func (service *Service) Finish(status jrpc2.ServerStatus) {
+func (service *Service) Finish(_ jrpc2.Assigner, status jrpc2.ServerStatus) {
 	if status.Closed() || status.Err != nil {
 		service.logger.Printf("Session stopped (err: %v)", status.Err)
 	}

--- a/langserver/instance/instance.go
+++ b/langserver/instance/instance.go
@@ -8,7 +8,7 @@ import (
 // ServerInstance is a jrpc2.Server with support for server.Service
 type ServerInstance struct {
 	Server     *jrpc2.Server
-	CancelFunc func(jrpc2.ServerStatus)
+	CancelFunc func(jrpc2.Assigner, jrpc2.ServerStatus)
 }
 
 // Start will call jrpc2.Server's Start method
@@ -19,7 +19,7 @@ func (instance *ServerInstance) Start(ch channel.Channel) {
 // Wait will cancel the current instance with the server's wait status
 func (instance *ServerInstance) Wait() {
 	status := instance.Server.WaitStatus()
-	instance.CancelFunc(status)
+	instance.CancelFunc(nil, status)
 }
 
 // StartAndWait will start the server and then put it in "wait" status

--- a/langserver/session/session_factory.go
+++ b/langserver/session/session_factory.go
@@ -10,7 +10,7 @@ import (
 // ServiceSession is an interface used to instantiate a JSON-RPC service
 type ServiceSession interface {
 	Assigner() (jrpc2.Assigner, error)
-	Finish(jrpc2.ServerStatus)
+	Finish(jrpc2.Assigner, jrpc2.ServerStatus)
 	SetLogger(*log.Logger)
 }
 


### PR DESCRIPTION
In preparation for committing to a stable v1 release for jrpc2 package, I have
made a number of updates to the library to simplify the API a bit. These
changes are discussed in https://github.com/creachadair/jrpc2/issues/46 if you
would like to offer any input.

This commit updates the package version used here to the latest tag as of this
writing, v0.19.0, and updates the existing use to match the changes. These
changes should not produce any functional differences.